### PR TITLE
fix open snippets

### DIFF
--- a/lib/snippets.js
+++ b/lib/snippets.js
@@ -31,7 +31,7 @@ module.exports = {
 
     this.subscriptions = new CompositeDisposable
     this.subscriptions.add(atom.workspace.addOpener(uri => {
-      if (uri === 'atom://.atom/snippets') {
+      if (uri === 'atom://.pulsar/snippets') {
         return atom.workspace.openTextFile(this.getUserSnippetsPath())
       }
     }))


### PR DESCRIPTION
This fixes that the wrong file is opened when you use the command "open your snippets". [pulsar/#88](https://github.com/pulsar-edit/pulsar/issues/88)
The error was that the uri was not updated in the snippets package.