### PR TITLE
Remove implicit `g` flag from snippet transformations

### DIFF
--- a/lib/snippet-body.pegjs
+++ b/lib/snippet-body.pegjs
@@ -63,8 +63,8 @@ variableContentChar = !variable char:('\\}' / [^}]) { return char; }
 escapedForwardSlash = pair:'\\/' { return pair; }
 
 // A pattern and replacement for a transformed tab stop.
-transformationSubstitution = '/' find:(escapedForwardSlash / [^/])* '/' replace:formatString* '/' flags:[imy]* {
-  let reFind = new RegExp(find.join(''), flags.join('') + 'g');
+transformationSubstitution = '/' find:(escapedForwardSlash / [^/])* '/' replace:formatString* '/' flags:[gimy]* {
+  let reFind = new RegExp(find.join(''), flags.join(''));
   return { find: reFind, replace: replace[0] };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snippets",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "main": "./lib/snippets",
   "description": "Expand snippets matching the current prefix with `tab`.",
   "repository": "https://github.com/atom/snippets",

--- a/spec/body-parser-spec.js
+++ b/spec/body-parser-spec.js
@@ -72,13 +72,26 @@ the quick brown $1fox \${2:jumped \${3:over}
       '>',
       {index: 0, content: []},
       '</',
+      {index: 1, content: [], substitution: {find: /f/, replace: ['F']}},
+      '>'
+    ]);
+  });
+
+  it("parses a snippet with transformations and a global flag", () => {
+    const bodyTree = BodyParser.parse("<${1:p}>$0</${1/f/F/g}>");
+    expect(bodyTree).toEqual([
+      '<',
+      {index: 1, content: ['p']},
+      '>',
+      {index: 0, content: []},
+      '</',
       {index: 1, content: [], substitution: {find: /f/g, replace: ['F']}},
       '>'
     ]);
   });
 
   it("parses a snippet with multiple tab stops with transformations", () => {
-    const bodyTree = BodyParser.parse("${1:placeholder} ${1/(.)/\\u$1/} $1 ${2:ANOTHER} ${2/^(.*)$/\\L$1/} $2");
+    const bodyTree = BodyParser.parse("${1:placeholder} ${1/(.)/\\u$1/g} $1 ${2:ANOTHER} ${2/^(.*)$/\\L$1/} $2");
     expect(bodyTree).toEqual([
       {index: 1, content: ['placeholder']},
       ' ',
@@ -102,7 +115,7 @@ the quick brown $1fox \${2:jumped \${3:over}
         index: 2,
         content: [],
         substitution: {
-          find: /^(.*)$/g,
+          find: /^(.*)$/,
           replace: [
             {escape: 'L'},
             {backreference: 1}
@@ -116,7 +129,7 @@ the quick brown $1fox \${2:jumped \${3:over}
 
 
   it("parses a snippet with transformations and mirrors", () => {
-    const bodyTree = BodyParser.parse("${1:placeholder}\n${1/(.)/\\u$1/}\n$1");
+    const bodyTree = BodyParser.parse("${1:placeholder}\n${1/(.)/\\u$1/g}\n$1");
     expect(bodyTree).toEqual([
       {index: 1, content: ['placeholder']},
       '\n',
@@ -148,7 +161,7 @@ the quick brown $1fox \${2:jumped \${3:over}
         index: 1,
         content: [],
         substitution: {
-          find: /(.)(.*)/g,
+          find: /(.)(.*)/,
           replace: [
             {escape: 'u'},
             {backreference: 1},
@@ -174,7 +187,7 @@ the quick brown $1fox \${2:jumped \${3:over}
         index: 1,
         content: [],
         substitution: {
-          find: /(.)\/(.*)/g,
+          find: /(.)\/(.*)/,
           replace: [
             {escape: 'u'},
             {backreference: 1},

--- a/spec/snippets-spec.js
+++ b/spec/snippets-spec.js
@@ -265,19 +265,19 @@ third tabstop $3\
           },
           "transform with non-transforming mirrors": {
             prefix: "t13",
-            body: "${1:placeholder}\n${1/(.)/\\u$1/}\n$1"
+            body: "${1:placeholder}\n${1/(.)/\\u$1/g}\n$1"
           },
           "multiple tab stops, some with transforms and some without": {
             prefix: "t14",
-            body: "${1:placeholder} ${1/(.)/\\u$1/} $1 ${2:ANOTHER} ${2/^(.*)$/\\L$1/} $2"
+            body: "${1:placeholder} ${1/(.)/\\u$1/g} $1 ${2:ANOTHER} ${2/^(.*)$/\\L$1/} $2"
           },
           "has a transformed tab stop without a corresponding ordinary tab stop": {
             prefix: 't15',
-            body: "${1/(.)/\\u$1/} & $2"
+            body: "${1/(.)/\\u$1/g} & $2"
           },
           "has a transformed tab stop that occurs before the corresponding ordinary tab stop": {
             prefix: 't16',
-            body: "& ${1/(.)/\\u$1/} & ${1:q}"
+            body: "& ${1/(.)/\\u$1/g} & ${1:q}"
           },
           "has a placeholder that mirrors another tab stop's content": {
             prefix: 't17',
@@ -285,7 +285,7 @@ third tabstop $3\
           },
           "has a transformed tab stop such that it is possible to move the cursor between the ordinary tab stop and its transformed version without an intermediate step": {
             prefix: 't18',
-            body: '// $1\n// ${1/./=/}'
+            body: '// $1\n// ${1/./=/g}'
           },
           "has two tab stops adjacent to one another": {
             prefix: 't19',
@@ -294,6 +294,14 @@ third tabstop $3\
           "has several adjacent tab stops, one of which has a placeholder with reference to another tab stop at its edge": {
             prefix: 't20',
             body: '${1:foo}${2:bar}${3:baz $1}$4'
+          },
+          "banner without global flag": {
+            prefix: "bannerWrong",
+            body: "// $1\n// ${1/./=/}"
+          },
+          "banner with globalFlag": {
+            prefix: "bannerCorrect",
+            body: "// $1\n// ${1/./=/g}"
           }
         }
       });
@@ -901,6 +909,28 @@ FOO
 foo\
 `
         );
+      });
+    });
+
+    describe("when the snippet contains a transformation without a global flag", () => {
+      it("should transform only the first character", () => {
+        editor.setText('bannerWrong');
+        editor.setCursorScreenPosition([0, 11]);
+        simulateTabKeyEvent();
+        expect(editor.getText()).toBe("// \n// ");
+        editor.insertText('TEST');
+        expect(editor.getText()).toBe("// TEST\n// =EST");
+      });
+    });
+
+    describe("when the snippet contains a transformation with a global flag", () => {
+      it("should transform all characters", () => {
+        editor.setText('bannerCorrect');
+        editor.setCursorScreenPosition([0, 13]);
+        simulateTabKeyEvent();
+        expect(editor.getText()).toBe("// \n// ");
+        editor.insertText('TEST');
+        expect(editor.getText()).toBe("// TEST\n// ====");
       });
     });
 


### PR DESCRIPTION

Breaks backward-compatibility, but fixes a bug because this was never supposed to work this way.

### Description of the Change

I added the original [support for snippet transformations](https://github.com/atom/snippets/pull/260) back in the day. It took me more than a year to realize that [I’d implemented it wrong](https://github.com/atom/snippets/pull/288#issuecomment-504782706), and that the regex syntax for transformations did not have an implied “global” flag.

As a result, transformations have behaved differently (in a subtle way) in Atom/Pulsar than in TextMate, VSCode, and probably any other editor that supports snippets. Since snippet syntax is now [part of the LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#snippet_syntax), this needs fixing, even if it will break backward-compatibility.

### Alternate Designs

None were considered. This fix was straightforward and touched two lines of the PEG file.

### Benefits

Some snippets that worked fine in other IDEs would’ve behaved differently in Pulsar, but would now behave identically after this change.

### Possible Drawbacks

Breaking backward-compatibility. But here’s why I don’t think this will affect many people:

* It’s an advanced feature that I think most users have never used, even in other IDEs.
* Though the snippet transformation feature was present in TextMate and other IDEs, it was never documented in the Flight Manual, so I don’t think it ever saw widespread usage in Atom.
* In the ~17 months it took me to realize that this was broken, zero people opened an issue in `atom/snippets` to complain.

And even if all that weren’t true, it’s a bullet that we’d need to bite anyway, because it does us no good to hang onto a subtle incompatibility in snippet syntax.

### Applicable Issues

[atom/snippets#288](https://github.com/atom/snippets/pull/288) contains a lot of further work by @Aerijo that is worth revisiting. At the time, it didn’t get much traction because it was a massive rewrite, and @Aerijo eventually decided to write their own package to _replace_ snippets, _à la_ `autocomplete-plus`. Attaining full feature parity with LSP snippets is still a good goal, and I think we can get there incrementally.