### PR TITLE
Fixed flaky test

### DIFF
--- a/spec/snippet-loading-spec.js
+++ b/spec/snippet-loading-spec.js
@@ -112,8 +112,8 @@ describe("Snippet Loading", () => {
   describe("::loadPackageSnippets(callback)", () => {
     beforeEach(() => { // simulate a list of packages where the javascript core package is returned at the end
       atom.packages.getLoadedPackages.andReturn([
-        atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'package-with-snippets')),
-        atom.packages.loadPackage('language-javascript')
+        atom.packages.loadPackage('language-javascript'),
+        atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'package-with-snippets'))
       ]);
     });
 

--- a/spec/snippet-loading-spec.js
+++ b/spec/snippet-loading-spec.js
@@ -110,10 +110,19 @@ describe("Snippet Loading", () => {
   });
 
   describe("::loadPackageSnippets(callback)", () => {
+    const jsPackage = () => {
+      const pack = atom.packages.loadPackage('language-javascript')
+      pack.path = path.join(
+        atom.getLoadSettings().resourcePath,
+        'node_modules', 'language-javascript'
+      )
+      return pack
+    }
+
     beforeEach(() => { // simulate a list of packages where the javascript core package is returned at the end
       atom.packages.getLoadedPackages.andReturn([
-        atom.packages.loadPackage('language-javascript'),
-        atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'package-with-snippets'))
+        atom.packages.loadPackage(path.join(__dirname, 'fixtures', 'package-with-snippets')),
+        jsPackage()
       ]);
     });
 


### PR DESCRIPTION
So... this is the stupidest shit ever, but let's go:

Snippets package basically have **no way** of knowing if a package is "core" or not. So they actually do something weird - the last package that gets activated is the one that basically gets to define the snippet, in case of conflicting snippets keys.

But that's the problem: package activation is _async_ - meaning that the order is not guaranteed. So the way the package decides if an user-installed package will have the snippet, is to **sort** packages by their **directory** - if a package contains `node_modules` on their path, it'll be considered a "core" package and it'll be sorted lower (I _wish_ I was making this up, [but unfortunately, I am not](https://github.com/pulsar-edit/snippets/blob/fix-flaky-test/lib/snippets.js#L356-L358)).

Which brings us to the worst problem so far: when `language-javascript` was not inside the `packages` directory, things were working just fine. Now... well, they are not - so Pulsar, on the CI, checks that `language-javascript` is inside the `packages` directory, and it uses that path instead of the one that's inside `node_modules` (why? Again, no idea - it shouldn't do that, honestly).

So this PR fixes this issue by **patching** the package to have a different directory.