### PR TITLE
Get `snippets` specs passing on modern Tree-sitter

### DIFF
--- a/spec/snippets-spec.js
+++ b/spec/snippets-spec.js
@@ -5,6 +5,7 @@ const {TextEditor} = require('atom');
 
 describe("Snippets extension", () => {
   let editorElement, editor, languageMode;
+  let modernTreeSitterIsDefault = null;
 
   const simulateTabKeyEvent = (param) => {
     if (param == null) {
@@ -16,6 +17,15 @@ describe("Snippets extension", () => {
   };
 
   beforeEach(async () => {
+    if (modernTreeSitterIsDefault === null) {
+      let oldSetting = atom.config.getSchema('core.useExperimentalModernTreeSitter');
+      if (oldSetting?.type === 'boolean') {
+        modernTreeSitterIsDefault = false;
+      }
+    }
+    if (!modernTreeSitterIsDefault) {
+      atom.config.set('core.useExperimentalModernTreeSitter', true);
+    }
     if (atom.notifications != null) { spyOn(atom.notifications, 'addError'); }
     spyOn(Snippets, 'loadAll');
     spyOn(Snippets, 'getUserSnippetsPath').andReturn('');


### PR DESCRIPTION
This is the only one I had to fix that's still external rather than bundled. And it was one of the harder ones!

For context, [consult this PR](https://github.com/pulsar-edit/pulsar/pull/855).