### PR TITLE
Add support for variables `LINE_COMMENT`, `BLOCK_COMMENT_START`…

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The following features from VSCode snippets are not yet supported:
 
 Pulsar snippets support all of the variables mentioned in the [LSP specification][lsp], plus many of the variables [supported by VSCode][vscode].
 
-Variables can be referenced with `$`, either without braces (`$CLIPBOARD`) or with braces (`${CLIPBOARD}`). Variables can also have fallback values (`${CLIPBOARD:http://example.com}`), simple flag-based transformations (`${CLIPBOARD:/upcase}`), or `sed`-style transformations `${CLIPBOARD/ /_/g}`.
+Variables can be referenced with `$`, either without braces (`$CLIPBOARD`) or with braces (`${CLIPBOARD}`). Variables can also have fallback values (`${CLIPBOARD:http://example.com}`), simple flag-based transformations (`${CLIPBOARD:/upcase}`), or `sed`-style transformations (`${CLIPBOARD/ /_/g}`).
 
 One of the most useful is `TM_SELECTED_TEXT`, which represents whatever text was selected when the snippet was invoked. (Naturally, this can only happen when a snippet is invoked via command or key shortcut, rather than by typing in a <kbd>Tab</kbd> trigger.)
 
@@ -118,8 +118,9 @@ Others that can be useful:
 * `TM_CURRENT_WORD`: The entire word that the cursor is within or adjacent to, as interpreted by `cursor.getCurrentWordBufferRange`.
 * `CLIPBOARD`: The current contents of the clipboard.
 * `CURRENT_YEAR`, `CURRENT_MONTH`, et cetera: referneces to the current date and time in various formats.
+* `LINE_COMMENT`, `BLOCK_COMMENT_START`, `BLOCK_COMMENT_END`: uses the correct comment delimiters for whatever language you’re in.
 
-Any variable that has no value — for instance, `TM_FILENAME` on an untitled document — will resolve to an empty string.
+Any variable that has no value — for instance, `TM_FILENAME` on an untitled document, or `LINE_COMMENT` in a CSS file — will resolve to an empty string.
 
 #### Variable transformation flags
 
@@ -140,10 +141,7 @@ Pulsar supports the three flags defined in the [LSP snippets specification][lsp]
 
 Of the variables supported by VSCode, Pulsar does not yet support:
 
-* `UUID`
-* `BLOCK_COMMENT_START`
-* `BLOCK_COMMENT_END`
-* `LINE_COMMENT`
+* `UUID` (Will automatically be supported when Pulsar uses a version of Electron that has native `crypto.randomUUID`.)
 
 ## Multi-line Snippet Body
 

--- a/lib/variable.js
+++ b/lib/variable.js
@@ -150,16 +150,30 @@ const RESOLVERS = {
 
   'RANDOM_HEX' () {
     return Math.random().toString(16).slice(-6)
+  },
+
+  'BLOCK_COMMENT_START' ({editor, cursor}) {
+    let delimiters = editor.getCommentDelimitersForBufferPosition(
+      cursor.getBufferPosition()
+    )
+    return (delimiters?.block?.[0] ?? '').trim()
+  },
+
+  'BLOCK_COMMENT_END' ({editor, cursor}) {
+    let delimiters = editor.getCommentDelimitersForBufferPosition(
+      cursor.getBufferPosition()
+    )
+    return (delimiters?.block?.[1] ?? '').trim()
+  },
+
+  'LINE_COMMENT' ({editor, cursor}) {
+    let delimiters = editor.getCommentDelimitersForBufferPosition(
+      cursor.getBufferPosition()
+    )
+    return (delimiters?.line ?? '').trim()
   }
 
   // TODO: VSCode also supports:
-  //
-  // BLOCK_COMMENT_START
-  // BLOCK_COMMENT_END
-  // LINE_COMMENT
-  //
-  // (grammars don't provide this information right now; see
-  // https://github.com/atom/atom/pull/18816)
   //
   // UUID
   //
@@ -243,7 +257,6 @@ class Variable {
       // This is the more complex sed-style substitution.
       let {find, replace} = this.substitution
       this.replacer ??= new Replacer(replace)
-      let matches = base.match(find)
       return base.replace(find, (...args) => {
         return this.replacer.replace(...args)
       })


### PR DESCRIPTION
…and `BLOCK_COMMENT_END`.

These are three of the four snippet variables that VSCode supports and we don't. You can do some nifty stuff with these, as [`pulsar`#970](https://github.com/pulsar-edit/pulsar/pull/970)'s description illustrates.

The only one we don't yet support is `UUID`, and I've set that up so that we get it for free whenever we upgrade Electron. We are _this close_ (imagine an index finger and a thumb very close together) to having a version of node with `crypto.randomUUID`; it'll basically happen whenever we upgrade Electron, even if it's a tiny bump. So I also made it so that the `UUID` unit tests will start running automatically as well in that scenario.

Would love to get this merged a few days before the 15th so I have time to make a PR that bumps `snippets`. (This is one of the very few remaining bundled packages in a separate repo — maybe the _only_ one left? I'll have to address that soon.)

### Testing

Wrote some new specs. If they pass, we're good to go.

